### PR TITLE
agent: set default emission period to one minute

### DIFF
--- a/agent/requester.go
+++ b/agent/requester.go
@@ -35,7 +35,7 @@ func (r PeriodicRequester) Output() <-chan broker.Message {
 
 func (r PeriodicRequester) run() {
 	defer close(r.out)
-	emit := time.NewTicker(time.Second)
+	emit := time.NewTicker(time.Minute)
 	var prevErr error
 	for {
 		select {


### PR DESCRIPTION
In USB/serial mode, the default value of the emission period is always used, since there is no way to change it remotely. The default was one second, which is too fast. One minute is better.